### PR TITLE
Upgrade sqlc config to v2 config format

### DIFF
--- a/users/sqlc.yaml
+++ b/users/sqlc.yaml
@@ -1,14 +1,19 @@
-version: "1"
-packages:
-  - name: "users"
-    path: "."
-    queries: "queries"
-    schema: "migrations"
-    engine: "postgresql"
-    emit_json_tags: false
-    emit_prepared_queries: false
-    emit_interface: true
-    emit_exact_table_names: false
+version: '2'
+sql:
+- name: "users"
+  queries: "queries"
+  schema: "migrations"
+  engine: "postgresql"
+  gen:
+    go:
+      package: "users"
+      out: "."
+      emit_json_tags: false
+      emit_prepared_queries: false
+      emit_interface: true
+      emit_exact_table_names: false
 overrides:
-  - go_type: "github.com/jackc/pgtype.UUID"
-    db_type: "uuid"
+  go:
+    overrides:
+      - go_type: "github.com/jackc/pgtype.UUID"
+        db_type: "uuid"


### PR DESCRIPTION
Hi! I saw you sprucing up this repository. This repo (and your talks) greatly impacted me when I first saw it! I based our company's entire architecture around it, so it has a special place in my heart.

Anyway, I have since updated our own services to use sqlc's config version 2 format, as it is more flexible, and is the recommended way. I updated your own config here since you (and this repo) had meant so much to me.

I ran `make generate` and nothing else changed, so I'm guessing I ported it correctly!